### PR TITLE
Implement i18n with next-i18next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,11 @@
       "version": "1.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^1.35.4",
+        "i18next": "^25.4.2",
+        "i18next-browser-languagedetector": "^8.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-i18next": "^15.7.2",
         "react-router-dom": "^6.4.2",
         "react-tsparticles": "^2.1.3",
         "sass": "^1.56.1",
@@ -27,7 +30,7 @@
         "prettier": "2.7.1",
         "prettier-plugin-organize-imports": "^3.0.0",
         "tailwindcss": "^3.2.1",
-        "typescript": "^4.6.3",
+        "typescript": "^5.9.2",
         "vite": "^3.2.2"
       }
     },
@@ -386,6 +389,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1598,6 +1610,55 @@
         "node": ">=4"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.4.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.4.2.tgz",
+      "integrity": "sha512-gD4T25a6ovNXsfXY1TwHXXXLnD/K2t99jyYMCSimSCBnBRJVQr5j+VAaU83RJCPzrTGhVQ6dqIga66xO2rtd5g==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/immutable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
@@ -2056,6 +2117,32 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-i18next": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.2.tgz",
+      "integrity": "sha512-xJxq7ibnhUlMvd82lNC4te1GxGUMoM1A05KKyqoqsBXVZtEvZg/fz/fnVzdlY/hhQ3SpP/79qCocZOtICGhd3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.4.1",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -2768,16 +2855,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2867,6 +2955,15 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/webidl-conversions": {
@@ -3195,6 +3292,11 @@
       "requires": {
         "@babel/helper-plugin-utils": "^7.16.7"
       }
+    },
+    "@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA=="
     },
     "@babel/template": {
       "version": "7.16.7",
@@ -4013,6 +4115,30 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true
     },
+    "html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "requires": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "i18next": {
+      "version": "25.4.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.4.2.tgz",
+      "integrity": "sha512-gD4T25a6ovNXsfXY1TwHXXXLnD/K2t99jyYMCSimSCBnBRJVQr5j+VAaU83RJCPzrTGhVQ6dqIga66xO2rtd5g==",
+      "requires": {
+        "@babel/runtime": "^7.27.6"
+      }
+    },
+    "i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "requires": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "immutable": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
@@ -4263,8 +4389,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-3.0.0.tgz",
       "integrity": "sha512-juSCJs5TMOqGGPaN/A/1xzWFzRPH2LG1LPLCr64dzKaVnPafJdtgDNmDVlU+8A4LbQzVJg0DTvgA8swBuIUhlg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -4293,6 +4418,15 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
+      }
+    },
+    "react-i18next": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.2.tgz",
+      "integrity": "sha512-xJxq7ibnhUlMvd82lNC4te1GxGUMoM1A05KKyqoqsBXVZtEvZg/fz/fnVzdlY/hhQ3SpP/79qCocZOtICGhd3g==",
+      "requires": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
       }
     },
     "react-refresh": {
@@ -4870,9 +5004,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true
     },
     "update-browserslist-db": {
@@ -4911,6 +5045,11 @@
         "resolve": "^1.22.1",
         "rollup": "^2.79.1"
       }
+    },
+    "void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^1.35.4",
+    "i18next": "^25.4.2",
+    "i18next-browser-languagedetector": "^8.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-i18next": "^15.7.2",
     "react-router-dom": "^6.4.2",
     "react-tsparticles": "^2.1.3",
     "sass": "^1.56.1",
@@ -28,7 +31,7 @@
     "prettier": "2.7.1",
     "prettier-plugin-organize-imports": "^3.0.0",
     "tailwindcss": "^3.2.1",
-    "typescript": "^4.6.3",
+    "typescript": "^5.9.2",
     "vite": "^3.2.2"
   }
 }

--- a/src/common/component/CloseModal.tsx
+++ b/src/common/component/CloseModal.tsx
@@ -1,26 +1,26 @@
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 function CloseModal(props: { action: Function }) {
+  const { t } = useTranslation();
   return (
     <>
       <div className="w-10/12 md:w-1/2  bg-white rounded-2xl p-5">
         <div className="flex flex-col items-center justify-center space-y-10">
-          <p className="font-black text-2xl text-center">
-            Êtes vous sur de vouloir quitter cette partie ?
-          </p>
+          <p className="font-black text-2xl text-center">{t("common.confirmLeave")}</p>
           <div className="flex flex-row space-x-10 items-center justify-center">
             <button
               type="button"
               className="bg-[#D9D9D9] p-2 rounded-2xl transition ease-in delay-150 hover:scale-105 duration-200 hover:cursor-pointer">
               <Link to={"/"}>
-                <span className="font-black text-2xl text-center">Oui</span>
+                <span className="font-black text-2xl text-center">{t("common.yes")}</span>
               </Link>
             </button>
             <button
               type="button"
               onClick={() => props.action()}
               className="bg-[#D9D9D9] p-2 rounded-2xl transition ease-in delay-150 hover:scale-105 duration-200 hover:cursor-pointer">
-              <span className="font-black text-2xl text-center">Non</span>
+              <span className="font-black text-2xl text-center">{t("common.no")}</span>
             </button>
           </div>
         </div>

--- a/src/common/component/Signature.tsx
+++ b/src/common/component/Signature.tsx
@@ -1,10 +1,17 @@
+import { useTranslation } from "react-i18next";
+
 function Signature() {
+  const { i18n } = useTranslation();
   return (
     <>
       <div className="fixed bottom-0 left-1/2 -translate-y-1/2 -translate-x-1/2 hover:cursor-pointer">
-        <a href="https://github.com/corentinleberre" target="_blank">
-          <span className="text-gray-800">@corentinleberre</span>
-        </a>
+        <div className="flex items-center space-x-3">
+          <button className="text-gray-800 underline" onClick={() => i18n.changeLanguage("en")}>EN</button>
+          <button className="text-gray-800 underline" onClick={() => i18n.changeLanguage("fr")}>FR</button>
+          <a href="https://github.com/corentinleberre" target="_blank">
+            <span className="text-gray-800">@corentinleberre</span>
+          </a>
+        </div>
       </div>
     </>
   );

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,101 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import LanguageDetector from "i18next-browser-languagedetector";
+
+const resources = {
+  en: {
+    translation: {
+      menu: {
+        play: "🎲 Play",
+        freeMode: "🎲 Free mode",
+        rules: "📕 Rules",
+        title: "BISCUITE",
+      },
+      gameMenu: {
+        heading: "GAME MODE",
+        cards: {
+          free: {
+            title: "Free mode",
+            paragraph: "No rules here, make room for your imagination.",
+          },
+          classic: {
+            title: "Classic",
+            paragraph:
+              "This mode is the best way to discover the game. Treacherous dice combinations, create your rules, but be careful not to become the 4.1!",
+          },
+          nrv: {
+            title: "Nrv",
+            paragraph:
+              "Random gulp multipliers come into play... The goal is simple drink as much as possible.",
+          },
+          problems: {
+            title: "The problems",
+            paragraph: "Get ready to break friendships",
+          },
+        },
+      },
+      common: {
+        rollDice: "Roll the dice",
+        confirmLeave: "Are you sure you want to quit this game?",
+        yes: "Yes",
+        no: "No",
+      },
+    },
+  },
+  fr: {
+    translation: {
+      menu: {
+        play: "🎲 Jouer",
+        freeMode: "🎲 Mode libre",
+        rules: "📕 Règles",
+        title: "BISCUITE",
+      },
+      gameMenu: {
+        heading: "MODE DE JEU",
+        cards: {
+          free: {
+            title: "Mode libre",
+            paragraph: "Pas de règles ici, faites place a votre imagination.",
+          },
+          classic: {
+            title: "Classique",
+            paragraph:
+              "Ce mode est le meilleur moyen de découvrir le jeu. Des combinaisons de dès bien traitres, créée vos règles, mais attention à ne pas devenir la 4.1 !",
+          },
+          nrv: {
+            title: "Nrv",
+            paragraph:
+              "Des multiplicateurs de goulées aléatoires entrent en jeux... L’objectif est simple boire un maximum.",
+          },
+          problems: {
+            title: "Les problèmes",
+            paragraph: "Préparez vous à briser des amitiés",
+          },
+        },
+      },
+      common: {
+        rollDice: "Jeter les dès",
+        confirmLeave: "Êtes vous sur de vouloir quitter cette partie ?",
+        yes: "Oui",
+        no: "Non",
+      },
+    },
+  },
+};
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources,
+    fallbackLng: "en",
+    supportedLngs: ["en", "fr"],
+    interpolation: { escapeValue: false },
+    detection: {
+      order: ["querystring", "localStorage", "navigator"],
+      caches: ["localStorage"],
+    },
+  });
+
+export default i18n;
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { Suspense } from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import "./index.css";
+import "./i18n";
 import GameMenuView from "./view/game-menu/GameMenuView";
 import BiscuiteGameView from "./view/game/biscuite/BiscuiteGameView";
 import FreeGameView from "./view/game/free/FreeGameView";
@@ -13,15 +14,17 @@ import SplashscreenView from "./view/splashscreen/Splashscreen";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<SplashscreenView />} />
-        <Route path="/menu" element={<MenuView />} />
-        <Route path="/game/menu" element={<GameMenuView />} />
-        <Route path="/game/biscuite" element={<BiscuiteGameView />} />
-        <Route path="/game/free" element={<FreeGameView />} />
-        <Route path="/rules" element={<RulesView />} />
-      </Routes>
-    </BrowserRouter>
+    <Suspense fallback={null}>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<SplashscreenView />} />
+          <Route path="/menu" element={<MenuView />} />
+          <Route path="/game/menu" element={<GameMenuView />} />
+          <Route path="/game/biscuite" element={<BiscuiteGameView />} />
+          <Route path="/game/free" element={<FreeGameView />} />
+          <Route path="/rules" element={<RulesView />} />
+        </Routes>
+      </BrowserRouter>
+    </Suspense>
   </React.StrictMode>
 );

--- a/src/view/game-menu/GameMenuView.tsx
+++ b/src/view/game-menu/GameMenuView.tsx
@@ -1,32 +1,32 @@
 import Signature from "../../common/component/Signature";
 import GameCard from "./GameCard";
+import { useTranslation } from "react-i18next";
 
 function GameMenuView() {
+  const { t } = useTranslation();
   const cards = [
     {
       emoji: "🎲",
-      title: "Mode libre",
-      paragraph: "Pas de règles ici, faites place a votre imagination.",
+      title: t("gameMenu.cards.free.title"),
+      paragraph: t("gameMenu.cards.free.paragraph"),
       navigate: "/game/free",
     },
     {
       emoji: "🥳",
-      title: "Classique",
-      paragraph:
-        "Ce mode est le meilleur moyen de découvrir le jeu. Des combinaisons de dès bien traitres, créée vos règles, mais attention à ne pas devenir la 4.1 !",
+      title: t("gameMenu.cards.classic.title"),
+      paragraph: t("gameMenu.cards.classic.paragraph"),
       navigate: "/game/biscuite",
     },
     {
       emoji: "🍻",
-      title: "Nrv",
-      paragraph:
-        "Des multiplicateurs de goulées aléatoires entrent en jeux... L’objectif est simple boire un maximum.",
+      title: t("gameMenu.cards.nrv.title"),
+      paragraph: t("gameMenu.cards.nrv.paragraph"),
       navigate: "/game/menu",
     },
     {
       emoji: "🥵",
-      title: "Les problèmes",
-      paragraph: "Préparez vous à briser des amitiés",
+      title: t("gameMenu.cards.problems.title"),
+      paragraph: t("gameMenu.cards.problems.paragraph"),
       navigate: "/game/menu",
     },
   ];
@@ -34,7 +34,7 @@ function GameMenuView() {
     <>
       <div className="background-gradient h-full">
         <div className="flex justify-center">
-          <h1 className="text-3xl not-italic font-black m-5">MODE DE JEU</h1>
+          <h1 className="text-3xl not-italic font-black m-5">{t("gameMenu.heading")}</h1>
         </div>
         <div className="flex flex-col space-y-4 justify-between px-[4%]">
           {cards.map((card, index) => (

--- a/src/view/game/biscuite/BiscuiteGameView.tsx
+++ b/src/view/game/biscuite/BiscuiteGameView.tsx
@@ -14,8 +14,10 @@ import ALL_ACTIONS from "./actions";
 import play from "./game-logic";
 import NewRule from "./NewRule";
 import { particlesOptions } from "./particles";
+import { useTranslation } from "react-i18next";
 
 function BiscuiteGameView() {
+  const { t } = useTranslation();
   useEffect(() => updateGamePlayed("classic"), []);
 
   const particlesInit = async (main: any) => await loadFull(main);
@@ -67,7 +69,7 @@ function BiscuiteGameView() {
                 setResult(result);
                 addEl();
               }}>
-              Jeter les dès
+              {t("common.rollDice")}
             </button>
           </div>
         )}

--- a/src/view/game/free/FreeGameView.tsx
+++ b/src/view/game/free/FreeGameView.tsx
@@ -6,8 +6,10 @@ import DiceResult from "../../../common/component/DiceResult";
 import Modal from "../../../common/component/Modal";
 import { updateGamePlayed } from "../../../common/logic/analytics";
 import { dices } from "../../../common/logic/dices";
+import { useTranslation } from "react-i18next";
 
 function FreeGameView() {
+  const { t } = useTranslation();
   const [result, setResult] = useState<Array<number>>();
   const [showModal, setShowModal] = useState(false);
 
@@ -26,7 +28,7 @@ function FreeGameView() {
             className="rounded-full bg-white transition ease-in delay-150 hover:scale-105 duration-200 hover:cursor-pointer text-3xl font-black p-3 m-3 text-black w-full"
             onClick={() => setResult(dices())}
           >
-            Jeter les dès
+            {t("common.rollDice")}
           </button>
         </div>
       </div>

--- a/src/view/menu/MenuView.tsx
+++ b/src/view/menu/MenuView.tsx
@@ -1,16 +1,18 @@
 import GameButton from "../../common/component/GameButton";
+import { useTranslation } from "react-i18next";
 
 function MenuView() {
+  const { t } = useTranslation();
   const menu = [
-    { text: "🎲 Jouer", link: "/game/biscuite" },
-    { text: "🎲 Mode libre", link: "/game/free" },
-    { text: "📕 Règles", link: "/rules" },
+    { text: t("menu.play"), link: "/game/biscuite" },
+    { text: t("menu.freeMode"), link: "/game/free" },
+    { text: t("menu.rules"), link: "/rules" },
   ];
 
   return (
     <div className="flex flex-col items-center justify-around bg-[#28DAD4] h-full">
       <div className="flex flex-col items-center justify-center border-4 border-[#FF4571] rounded-full bg-[#4C4660] w-5/6 md:w-1/3 h-1/6">
-        <h1 className="text-white text-6xl font-semibold">BISCUITE</h1>
+        <h1 className="text-white text-6xl font-semibold">{t("menu.title")}</h1>
       </div>
       <div className="flex flex-col items-center justify-center w-5/6 md:w-2/3">
         {menu?.map((value, index) => (


### PR DESCRIPTION
Implement i18n with `react-i18next` for English and French, translating existing French UI strings.

The project is a Vite/React application, so `react-i18next` was used instead of `next-i18next` (which is for Next.js) to ensure compatibility. English is set as the default language, with literal translations provided for existing French texts.

---
<a href="https://cursor.com/background-agent?bcId=bc-4886753d-540f-4a8f-83cf-fbadb32fb15f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4886753d-540f-4a8f-83cf-fbadb32fb15f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

