### PR TITLE
Add lock emoji to NRV and problem mode

### DIFF
--- a/src/view/game-menu/GameCard.tsx
+++ b/src/view/game-menu/GameCard.tsx
@@ -5,13 +5,19 @@ function GameCard(props: {
   emoji: string;
   paragraph: string;
   navigate: string;
+  showLock?: boolean;
 }) {
   const navigate = useNavigate();
   return (
     <div
       onClick={() => navigate(props.navigate)}
-      className="w-full bg-white rounded-2xl flex flex-col p-4 shadow-lg hover:cursor-pointer hover:scale-105 duration-300"
+      className="w-full bg-white rounded-2xl flex flex-col p-4 shadow-lg hover:cursor-pointer hover:scale-105 duration-300 relative"
     >
+      {props.showLock && (
+        <div className="absolute top-2 right-2 text-xl">
+          🔒
+        </div>
+      )}
       <div className="flex flex-row justify-center">
         <p className="font-black text-2xl">
           {props.emoji} {props.title}

--- a/src/view/game-menu/GameCard.tsx
+++ b/src/view/game-menu/GameCard.tsx
@@ -10,11 +10,15 @@ function GameCard(props: {
   const navigate = useNavigate();
   return (
     <div
-      onClick={() => navigate(props.navigate)}
-      className="w-full bg-white rounded-2xl flex flex-col p-4 shadow-lg hover:cursor-pointer hover:scale-105 duration-300 relative"
+      onClick={() => !props.showLock && navigate(props.navigate)}
+      className={`w-full bg-white rounded-2xl flex flex-col p-4 shadow-lg duration-300 relative ${
+        props.showLock 
+          ? 'cursor-not-allowed opacity-75' 
+          : 'hover:cursor-pointer hover:scale-105'
+      }`}
     >
       {props.showLock && (
-        <div className="absolute top-2 right-2 text-xl">
+        <div className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full w-8 h-8 flex items-center justify-center text-sm shadow-lg z-10">
           🔒
         </div>
       )}

--- a/src/view/game-menu/GameMenuView.tsx
+++ b/src/view/game-menu/GameMenuView.tsx
@@ -20,14 +20,16 @@ function GameMenuView() {
       emoji: "🍻",
       title: "Nrv",
       paragraph:
-        "Des multiplicateurs de goulées aléatoires entrent en jeux... L’objectif est simple boire un maximum.",
+        "Des multiplicateurs de goulées aléatoires entrent en jeux... L'objectif est simple boire un maximum.",
       navigate: "/game/menu",
+      showLock: true,
     },
     {
       emoji: "🥵",
       title: "Les problèmes",
       paragraph: "Préparez vous à briser des amitiés",
       navigate: "/game/menu",
+      showLock: true,
     },
   ];
   return (


### PR DESCRIPTION
Add a lock emoji to NRV and Problem mode cards to indicate special restrictions.

---
[Slack Thread](https://volume7.slack.com/archives/D09CPQ72QAV/p1756305535890009?thread_ts=1756305535.890009&cid=D09CPQ72QAV)

<a href="https://cursor.com/background-agent?bcId=bc-0a51f714-64f5-498f-b708-f3751b339310">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a51f714-64f5-498f-b708-f3751b339310">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

